### PR TITLE
Do not err on SIGINT/Ctrl-c

### DIFF
--- a/autoload/thesaurus_query/thesaurus_query.py
+++ b/autoload/thesaurus_query/thesaurus_query.py
@@ -261,7 +261,7 @@ def tq_replace_cursor_word_from_candidates(candidate_list, source_backend=None):
             else:
                 thesaurus_user_choice = vim.eval("input('Type number and <Enter> (results truncated, Type `A<Enter>` to browse all resultsin split;\nempty cancels; 'n': use next backend; 'p' use previous backend): ')")
         except KeyboardInterrupt:
-            return None
+            return 0
         return thesaurus_user_choice
 
     thesaurus_user_choice = obtain_user_choice(truncated_flag)


### PR DESCRIPTION
Closing the split window by just pressing Enter works, but maybe it would be nice to handle Ctrl-C as well.

A more proper implementation would probably to use `signal.signal(signal.SIGINT, func)`: https://stackoverflow.com/a/1112350/220472
