### PR TITLE
Update thesaurus_com backend to support newest version

### DIFF
--- a/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
+++ b/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
@@ -25,7 +25,6 @@ except ImportError:
 import sys
 import subprocess
 import pkg_resources
-from collections import namedtuple
 from pkg_resources import DistributionNotFound, VersionConflict
 import re
 import socket
@@ -38,9 +37,6 @@ language="en"
 _python_dependencies = [
         'thesaurus>=0.2.3',
         ]
-
-# Used for handling exceptions where we can't fetch word data.
-EmptyWord = namedtuple('EmptyWord', ['data'])
 
 class _word_query_handler_thesaurus_lookup:
     '''
@@ -93,10 +89,7 @@ class _word_query_handler_thesaurus_lookup:
                 self._loaded=True
 
         if self._backendDisabled is False:
-            try:
-                self.query_result = self._Word(word)
-            except:
-                self.query_result = EmptyWord([])
+            self.query_result = self._Word(word)
 
     def synonym_found(self):
         if self._backendDisabled:
@@ -114,7 +107,12 @@ class _word_query_handler_thesaurus_lookup:
                 self.syno_list[-1][1].append(synItem.word)
 
     def query(self,word):
-        self.query_cmd_handler(word)
+        try:
+            self.query_cmd_handler(word)
+        except:
+            # Word constructor threw an exception.
+            return [-1, []]
+        
         query_status = self.synonym_found()
         if query_status!=0:
             return [query_status, self.syno_list]

--- a/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
+++ b/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
@@ -25,6 +25,7 @@ except ImportError:
 import sys
 import subprocess
 import pkg_resources
+from collections import namedtuple
 from pkg_resources import DistributionNotFound, VersionConflict
 import re
 import socket
@@ -35,8 +36,11 @@ identifier="thesaurus_com"
 language="en"
 
 _python_dependencies = [
-        'thesaurus>=0.2.2',
+        'thesaurus>=0.2.3',
         ]
+
+# Used for handling exceptions where we can't fetch word data.
+EmptyWord = namedtuple('EmptyWord', ['data'])
 
 class _word_query_handler_thesaurus_lookup:
     '''
@@ -89,7 +93,10 @@ class _word_query_handler_thesaurus_lookup:
                 self._loaded=True
 
         if self._backendDisabled is False:
-            self.query_result = self._Word(word)
+            try:
+                self.query_result = self._Word(word)
+            except:
+                self.query_result = EmptyWord([])
 
     def synonym_found(self):
         if self._backendDisabled:


### PR DESCRIPTION
Hi.

Basically, [this happened](https://github.com/Manwholikespie/thesaurus/issues/14). I went ahead and added some custom exceptions while I was at it, which means it will throw errors now if a word doesn't exist.

This fix should suppress those error messages while maintaining normal behavior.