### PR TITLE
Ask user to use correct python executable in Win32 vim

### DIFF
--- a/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
+++ b/autoload/thesaurus_query/backends/thesaurus_com_lookup.py
@@ -52,8 +52,12 @@ class _word_query_handler_thesaurus_lookup:
     '''
     def _try_to_install_thesaurus(self):
         if get_variable("tq_thesaurus_com_do_not_prompt_for_install", 0)==0:
+            if vim_eval("has('win32')") == "1":
+                python_binary = ':!python'
+            else:
+                python_binary = sys.executable
             userChoice = vim_eval("confirm(\"Please use '{} -m pip install thesaurus --user --upgrade' to install the latest package. Have you installed it now?\", \"&Yes\\n&Disable '{}' backend for this Vim session\")".format(
-                sys.executable, identifier, identifier))
+                python_binary, identifier, identifier))
             if userChoice == "1":
                 return True
             else:


### PR DESCRIPTION
Fix nonsensical error message when thesaurus module is missing.

Previously, I'd get:

> Please use 'c:appsvimvim81gvim.exe -m pip install thesaurus --user --upgrade' to install the latest package. Have you installed it now?

(Backslashes get treated as escapes so path looks weird.)

vim and gvim on Windows report gvim.exe as sys.executable instead of
python. Tell user to use python instead. Ask for python executed within
vim to increase chances it's the right python.

Tested error message on Win10 gvim.exe and vim.exe 8.1.527 and Ubuntu
(WSL) vim 7.4.52.

On Windows I now get:

> Please use ':!python -m pip install thesaurus --user --upgrade' to install the latest package. Have you installed it now?
