### PR TITLE
Set buffer name after turning off swap file

### DIFF
--- a/autoload/thesaurus_query/thesaurus_query.py
+++ b/autoload/thesaurus_query/thesaurus_query.py
@@ -379,13 +379,13 @@ def tq_generate_thesaurus_buffer(candidates):
     else:
         vim_command(
                 'exec ":silent keepalt belowright split ' + bufferWindowName)
-    vim_command(
-            'exec ":silent file ' + bufferWindowName)
 
     vim_command('setlocal noswapfile nobuflisted nospell nowrap modifiable nonumber foldcolumn=0')
     if vim_eval('exists("+relativenumber")')=='1':
         vim_command('setlocal norelativenumber')
     vim_command('setlocal buftype=nofile')
+    vim_command(
+            'exec ":silent file ' + bufferWindowName)
 
 # obtain window dimension:
     win_width = int(vim_eval('winwidth(0)'))


### PR DESCRIPTION
Prevent E325 (existing swap file) when using the :Thesaurus command by
renaming the buffer after we configure the buffer (including
noswapfile).

Issue was easily triggered 100% by running vim (8.1.527 on Windows10) like so:

    gvim +"Thesaurus hero"

And resulted in error:

    vim.error: Vim(file):E325: ATTENTION