### PR TITLE
Add french backend with synonymo.fr

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ quality source is either the OpenOffice Thesaurus source or mthesaur.txt. I am s
 
 -------
 
+Added new French backend based on [synonymo.fr](http://www.synonymo.fr/). To
+activate it, add `fr` to variable `g:tq_language` and `synonymo_fr` to
+`g:tq_enabled_backends`.
+
+-------
+
 Added new German backend based on
 [openthesaurus.com](https://www.openthesaurus.de/about/api#json). This
 thesaurus backend is one of the German default backends. To activate it, add

--- a/autoload/thesaurus_query/backends/cnrtl_fr_lookup.py
+++ b/autoload/thesaurus_query/backends/cnrtl_fr_lookup.py
@@ -9,15 +9,27 @@ try:
 except ImportError:
     from urllib.request import urlopen
     from urllib.error import URLError, HTTPError
+import sys
 import re
 import socket
-import bs4 as BeautifulSoup
-from ..tq_common_lib import fixurl, decode_utf_8, get_variable
+
+
+from ..tq_common_lib import fixurl, decode_utf_8, get_variable, vim_eval
 
 identifier="cnrtl_fr"
 language="fr"
 
 _timeout_period_default = 1.0
+_backendDisabled = False
+
+try:
+    import bs4 as BeautifulSoup
+except ImportError:
+    userChoice = vim_eval("confirm(\"Required package bs4 can not be imported. Please use '{} -m pip install bs4 --user --upgrade' to install the latest bs4. Do you want to try to import it again?\", \"&Yes\\n&Disable '{}' backend for this Vim session\")".format(sys.executable, identifier, identifier))
+    if userChoice == "1":
+        import bs4 as BeautifulSoup
+    else:
+        _backendDisabled = True
 
 def query(target, query_method="synonym"):
     ''' return result as list. relavance from high to low in each PoS.
@@ -31,6 +43,8 @@ nested list = [PoS, list wordlist]
     Classifier('str'): Identifier to classify the resulting wordlist suits.
     wordlist = [word_0, word_1, ...]: list of words belonging to a same definition
     '''
+    if _backendDisabled:
+        return [-1,[]]
     target=target.replace(u" ", u"+")
     result_lists =  _synonymo_fr_wrapper(target, query_method=query_method)
     if result_lists == -1:

--- a/autoload/thesaurus_query/backends/cnrtl_fr_lookup.py
+++ b/autoload/thesaurus_query/backends/cnrtl_fr_lookup.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# python wrapper for word query from synonymo.fr
+# Author:       Eloi perdereau [[eloi@perdereau.eu][E-mail]]
+
+try:
+    from urllib2 import urlopen
+    from urllib2 import URLError, HTTPError
+except ImportError:
+    from urllib.request import urlopen
+    from urllib.error import URLError, HTTPError
+import re
+import socket
+import bs4 as BeautifulSoup
+from ..tq_common_lib import fixurl, decode_utf_8, get_variable
+
+identifier="cnrtl_fr"
+language="fr"
+
+_timeout_period_default = 1.0
+
+def query(target, query_method="synonym"):
+    ''' return result as list. relavance from high to low in each PoS.
+Lookup routine for openthesaurus.de. When query_from_source is called, return:
+   [status, [[PoS, [word_0, word_1, ...]],  [PoS, [word_0, word_1, ...]], ...]]
+status:
+    0: normal,  result found, list will be returned as a nested list
+    1: normal, result not found, return empty list
+    -1: unexpected result from query, return empty list
+nested list = [PoS, list wordlist]
+    Classifier('str'): Identifier to classify the resulting wordlist suits.
+    wordlist = [word_0, word_1, ...]: list of words belonging to a same definition
+    '''
+    target=target.replace(u" ", u"+")
+    result_lists =  _synonymo_fr_wrapper(target, query_method=query_method)
+    if result_lists == -1:
+        return [-1,[]]
+    elif result_lists == 1:
+        return [1, []]
+    else:
+        return result_lists
+
+
+def get_html(url, time_out):
+    try:
+        response = urlopen(fixurl(url).decode('ASCII'), timeout = time_out)
+    except HTTPError:
+        return 1
+    except URLError as err:
+        if isinstance(err.reason, socket.timeout):  # timeout error?
+            return 1
+        return -1   # other error
+    except socket.timeout:  # timeout error failed to be captured by URLError
+        return 1
+    return response.read()
+
+
+def get_class_tds(soup, clas):
+    synonym_tds = soup.find_all('td', {'class': clas})
+    if not synonym_tds:
+        return []
+    else:
+        synonyms = [ td.a.get_text() for td in synonym_tds ]
+        return synonyms
+
+
+def _synonymo_fr_wrapper(target, query_method='synonym'):
+    '''
+    query_method:
+        synonym anyonym
+    '''
+    time_out_choice = float(get_variable(
+        'tq_online_backends_timeout', _timeout_period_default))
+    case_mapper={"synonym":u"synonymie",
+                 "antonym":u"antonymie",
+                }
+    class_mapper={"synonym":u"syno_format",
+                  "antonym":u"anto_format"
+                }
+    base_url = u'http://cnrtl.fr'
+    html = get_html(base_url+'/{0}/{1}'.format(
+                case_mapper[query_method], target), time_out_choice)
+
+    soup = BeautifulSoup.BeautifulSoup(html, features="html.parser")
+    if re.search('Erreur|Terme introuvable', soup.find(id="contentbox").get_text()):
+        return 1
+    targets_li = soup.find(id="vtoolbar").find_all('li')
+    synonym_lists = [ [targets_li[0].a.get_text(),
+                            get_class_tds(soup, class_mapper[query_method])] ]
+
+    # get alternative found targers
+    link_pattern = re.compile("sendRequest\(\d+,\s*'([^']*)'\)")
+    for alt_li in targets_li[1:]:
+        link = link_pattern.search(alt_li.a['onclick']).group(1)
+        alt_html = get_html(base_url+link, time_out_choice)
+        alt_soup = BeautifulSoup.BeautifulSoup(alt_html, features="html.parser")
+        synonym_lists.append([alt_li.a.get_text(),
+                            get_class_tds(alt_soup, class_mapper[query_method])])
+    return [ 0, synonym_lists ]
+

--- a/autoload/thesaurus_query/backends/synonymo_fr_lookup.py
+++ b/autoload/thesaurus_query/backends/synonymo_fr_lookup.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# python wrapper for word query from synonymo.fr
+# Author:       Eloi perdereau [[eloi@perdereau.eu][E-mail]]
+
+
+try:
+    from urllib2 import urlopen
+    from urllib2 import URLError, HTTPError
+except ImportError:
+    from urllib.request import urlopen
+    from urllib.error import URLError, HTTPError
+import socket
+import bs4 as BeautifulSoup
+from ..tq_common_lib import fixurl, decode_utf_8, get_variable
+
+identifier="synonymo_fr"
+language="fr"
+
+_timeout_period_default = 10.0
+
+def query(target, query_method="synonym"):
+    ''' return result as list. relavance from high to low in each PoS.
+Lookup routine for openthesaurus.de. When query_from_source is called, return:
+   [status, [[PoS, [word_0, word_1, ...]],  [PoS, [word_0, word_1, ...]], ...]]
+status:
+    0: normal,  result found, list will be returned as a nested list
+    1: normal, result not found, return empty list
+    -1: unexpected result from query, return empty list
+nested list = [PoS, list wordlist]
+    Classifier('str'): Identifier to classify the resulting wordlist suits.
+    wordlist = [word_0, word_1, ...]: list of words belonging to a same definition
+    '''
+    target=target.replace(u" ", u"+")
+    result_list=_synonymo_fr_wrapper(target, query_method=query_method)
+    if result_list == -1:
+        return [-1, []]
+    elif result_list == 1:
+        return [1, []]
+    else:
+        return _parser(result_list)
+
+
+def _synonymo_fr_wrapper(target, query_method='synonym'):
+    '''
+    query_method:
+        synonym anyonym
+    '''
+    time_out_choice = float(get_variable(
+        'tq_online_backends_timeout', _timeout_period_default))
+    case_mapper={"synonym":u"syno",
+                 "antonym":u"anto",
+                }
+
+    try:
+        response = urlopen(fixurl(
+            u'http://synonymo.fr/{0}/{1}'.format(
+                case_mapper[query_method], target
+                )).decode('ASCII'), timeout = time_out_choice)
+    except HTTPError:
+        return 1
+    except URLError as err:
+        if isinstance(err.reason, socket.timeout):  # timeout error?
+            return 1
+        return -1   # other error
+    except socket.timeout:  # timeout error failed to be captured by URLError
+        return 1
+    return response.read()
+
+def _parser(target_list):
+    soup = BeautifulSoup.BeautifulSoup(target_list, features="html.parser")
+    fiche = soup.find_all('div', {'class': 'fiche'})[0]
+    if "Aucun résultat" in fiche.h1:
+        return [1, []]
+    else:
+        synonym_list = [ a.get_text() for a in fiche.find_all('a', {'class': 'word'}) ]
+        if synonym_list:
+            return [0, [ ['', synonym_list ] ]]
+        else:   # parse error
+            return [-1, []]
+

--- a/autoload/thesaurus_query/thesaurus_query.py
+++ b/autoload/thesaurus_query/thesaurus_query.py
@@ -248,7 +248,6 @@ def tq_replace_cursor_word_from_candidates(candidate_list, source_backend=None):
 
     [candidate_num, thesaurus_wait_list, syno_result_IDed] = tq_candidate_list_populate(candidates)
 
-    vim_command("echon \"In line: ... \"|echohl Keyword|echon \"{0}\"|echohl None |echon \" ...\n\"".format(vim.current.line.replace('\\','\\\\').replace('"','\\"')))
     vim_command("echohl None| echon \"Candidates for \"| echohl WarningMSG | echon \"{0}\" | echohl None | echon \", found by backend: \" | echohl Keyword | echon \"{1}\n\"".format(
         vim.eval("l:trimmed_word").replace('\\','\\\\').replace('"','\\"'),
         source_backend
@@ -262,9 +261,9 @@ def tq_replace_cursor_word_from_candidates(candidate_list, source_backend=None):
         '''
         try:
             if trunc_flag==0:
-                thesaurus_user_choice=vim.eval("input(\"Type number and <Enter> (empty cancels; 'n': use next backend; 'p' use previous backend): \")")
+                thesaurus_user_choice=vim.eval("input(\"'': cancel; 'n': next backend; 'p' previous backend: \")")
             else:
-                thesaurus_user_choice = vim.eval("input('Type number and <Enter> (results truncated, Type `A<Enter>` to browse all resultsin split;\nempty cancels; 'n': use next backend; 'p' use previous backend): ')")
+                thesaurus_user_choice = vim.eval("input('Results truncated, Type `A<Enter>` to browse all results in split;\n'': cancel; 'n': next backend; 'p' previous backend: ')")
         except (KeyboardInterrupt if not neovimUsed else (KeyboardInterrupt, neovim.api.nvim.NvimError)):
             return None
         return thesaurus_user_choice
@@ -372,7 +371,7 @@ def tq_generate_thesaurus_buffer(candidates):
     ''' generate a buffer in Vim to show all found synonyms from query '''
     if independent_session:     # this module don't work in Vim independent session
         return None
-    bufferWindowName='thesaurus:\\\\ " . l:word_fname . "\\\\ (press\\\\ q\\\\ to\\\\ close\\\\ this\\\\ split.)"'
+    bufferWindowName='thesaurus:\\\\ " . l:word_fname'
     vim_command("silent! let l:thesaurus_window = bufwinnr('^thesaurus: ')")
     if int(vim.eval("l:thesaurus_window")) > -1:
         vim_command('exec l:thesaurus_window . "wincmd w"')
@@ -400,30 +399,27 @@ def tq_generate_thesaurus_buffer(candidates):
             [ word1, word2, word3, ... ]
         """
         tq_thesaurus_buffer.append([""])
-        tq_thesaurus_buffer[-1]='Synonyms:'
+        tq_thesaurus_buffer[-1]='Synonyms: '
         column_curr = 10
         word_list_size = len(word_list)
 
         for word_curr in enumerate(word_list):
             if column_curr+len(word_curr[1])+_double_width_char_count(word_curr[1])+2 >= win_width:
-                tq_thesaurus_buffer.append(["         "])
+                tq_thesaurus_buffer.append(["          "])
                 column_curr = 10
             if word_curr[0]<word_list_size-1:
                 tq_thesaurus_buffer[-1]+= \
-                    send_string_to_vim(''.join([' ', word_curr[1], ',']))
+                    send_string_to_vim(word_curr[1] + ', ')
                 column_curr += len(word_curr[1])+_double_width_char_count(word_curr[1])+2
             else:
                 tq_thesaurus_buffer[-1]+= \
                     send_string_to_vim(word_curr[1])
 
-    tq_thesaurus_buffer[-1]="Result for word \"{0}\" (press \"q\" to close this split)".format(vim.eval('l:word'))
     for case in candidates:
-        tq_thesaurus_buffer.append([""])
         if not case[0]:
             candidate_list_printing(case[1])
             continue
-        tq_thesaurus_buffer.append([""])
-        tq_thesaurus_buffer[-1]='Found_as: {0}'.format(send_string_to_vim(case[0]))
+        tq_thesaurus_buffer[-1]='Found as: {0}'.format(send_string_to_vim(case[0]))
         candidate_list_printing(case[1])
     vim_command("setlocal bufhidden=")
     vim_command("exec 'resize ' . (line('$'))")


### PR DESCRIPTION
Hi,

Great plugin! Missing French support for me :)

I used `BeautifulSoup` to parse the html of [synonymo.fr](http://synonymo.fr). I also made a version with only `html.parser` [here](https://github.com/perelo/thesaurus_query.vim/commit/774114578ee8c4140190286ea18e7473543321c7) based on what was done in `woxikon_de_lookup.py`. But the result is much longer and less readable.
Let me know if you feel that `BeautifulSoup` dependency seems cumbersome.